### PR TITLE
Fix phone attribute validation

### DIFF
--- a/PA_BE/Models/Employee.cs
+++ b/PA_BE/Models/Employee.cs
@@ -16,7 +16,7 @@ namespace PermAdminAPI.Models
         public string Email { get; set; }
         
         [Required(ErrorMessage = "Phone number is required")]
-        [Length(9, 13)]
+        [StringLength(13, MinimumLength = 9)]
         public string Phone { get; set; }
         
         [Required(ErrorMessage = "Position is required")]


### PR DESCRIPTION
## Summary
- use `StringLength` for phone number validation

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589de6b590832d989f43ca85cce150