### PR TITLE
Add licence users view

### DIFF
--- a/PA_BE/Controllers/LicenceController.cs
+++ b/PA_BE/Controllers/LicenceController.cs
@@ -235,6 +235,26 @@ public async Task<ActionResult<Licence>> CreateLicence(Licence licence)
             return Ok(assignedLicences);
         }
 
+        [HttpGet("assigned-licences/licence/{licenceId}")]
+        public async Task<ActionResult<IEnumerable<AssignLicenceDTO>>> GetAssignedLicencesByLicence(int licenceId)
+        {
+            var assignedLicences = await context.EmployeeLicences
+                .Where(el => el.licenceId == licenceId)
+                .Include(el => el.Employee)
+                .Include(el => el.Licence)
+                .Select(el => new AssignLicenceDTO
+                {
+                    Id = el.id,
+                    EmployeeId = el.employeeId,
+                    LicenceId = el.licenceId,
+                    EmployeeName = $"{el.Employee.FirstName} {el.Employee.LastName}",
+                    LicenceName = el.Licence.ApplicationName
+                })
+                .ToListAsync();
+
+            return Ok(assignedLicences);
+        }
+
         [HttpDelete("assigned-licences/{id}")]
         public async Task<IActionResult> DeleteAssignedLicence(int id)
         {

--- a/PA_FE/src/_services/licence.service.ts
+++ b/PA_FE/src/_services/licence.service.ts
@@ -38,6 +38,12 @@ export class LicenceService {
     );
   }
 
+  getEmployeesByLicenceId(licenceId: number): Observable<AssignLicenceDTO[]> {
+    return this.http.get<AssignLicenceDTO[]>(
+      `${this.apiUrl}/assigned-licences/licence/${licenceId}`
+    );
+  }
+
   deleteAssignedLicence(assignmentId: number): Observable<void> {
     return this.http.delete<void>(
       `${this.apiUrl}/assigned-licences/${assignmentId}`

--- a/PA_FE/src/app/app.routes.ts
+++ b/PA_FE/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { LicenceTableComponent } from './licence-table/licence-table.component';
 import { LicenceFormComponent } from './licence-form/licence-form.component';
 import { EmployeeDetailsComponent } from './employee-details/employee-details.component';
 import { AssignLicenseComponent } from './assign-license/assign-license.component';
+import { LicenceDetailsComponent } from './licence-details/licence-details.component';
 
 export const routes: Routes = [
   { path: '', component: EmployeeTableComponent },
@@ -14,5 +15,6 @@ export const routes: Routes = [
   { path: 'editLicence/:id', component: LicenceFormComponent },
   { path: 'createLicence', component: LicenceFormComponent },
   { path: 'employeeDetails/:id', component: EmployeeDetailsComponent },
+  { path: 'licenceDetails/:id', component: LicenceDetailsComponent },
   { path: 'assign-license/:employeeId', component: AssignLicenseComponent},]
 ;

--- a/PA_FE/src/app/licence-details/licence-details.component.html
+++ b/PA_FE/src/app/licence-details/licence-details.component.html
@@ -1,0 +1,44 @@
+<div class="container mt-5">
+  <div class="card mb-4">
+    <div class="card-header bg-primary text-white">
+      <h2 class="mb-0">Licence Information</h2>
+    </div>
+    <div class="card-body" *ngIf="licence">
+      <ul class="list-group">
+        <li class="list-group-item"><strong>ID:</strong> {{ licence.id }}</li>
+        <li class="list-group-item"><strong>Name:</strong> {{ licence.applicationName }}</li>
+        <li class="list-group-item"><strong>Available:</strong> {{ licence.quantity }}</li>
+      </ul>
+    </div>
+    <div *ngIf="!licence" class="card-body text-center">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header bg-primary text-white">
+      <h4 class="mb-0">Users with this licence</h4>
+    </div>
+    <div class="card-body">
+      <div *ngIf="assignedUsers.length > 0; else noUsers">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>User</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let user of assignedUsers">
+              <td>{{ user.employeeName }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ng-template #noUsers>
+        <div class="alert alert-info">No users assigned to this licence.</div>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/PA_FE/src/app/licence-details/licence-details.component.ts
+++ b/PA_FE/src/app/licence-details/licence-details.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { LicenceService } from '../../_services/licence.service';
+import { Licence } from '../../_models/Licence';
+import { AssignLicenceDTO } from '../../_models/AssignLicenceDTO';
+
+@Component({
+  selector: 'app-licence-details',
+  templateUrl: './licence-details.component.html',
+  styleUrls: ['./licence-details.component.css'],
+  imports: [CommonModule, RouterModule],
+})
+export class LicenceDetailsComponent implements OnInit {
+  licence: Licence | null = null;
+  assignedUsers: AssignLicenceDTO[] = [];
+  errorMessage = '';
+
+  constructor(
+    private licenceService: LicenceService,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe(params => {
+      const id = params.get('id');
+      if (id) {
+        this.loadLicence(+id);
+        this.loadAssignedUsers(+id);
+      }
+    });
+  }
+
+  loadLicence(id: number): void {
+    this.licenceService.getLicenceById(id).subscribe({
+      next: licence => (this.licence = licence),
+      error: err => {
+        console.error('Error loading licence', err);
+        this.errorMessage = 'Failed to load licence details';
+      },
+    });
+  }
+
+  loadAssignedUsers(licenceId: number): void {
+    this.licenceService.getEmployeesByLicenceId(licenceId).subscribe({
+      next: users => (this.assignedUsers = users),
+      error: err => {
+        console.error('Error loading users', err);
+        this.errorMessage = `Failed to load users: ${err.message}`;
+      },
+    });
+  }
+}

--- a/PA_FE/src/app/licence-table/licence-table.component.html
+++ b/PA_FE/src/app/licence-table/licence-table.component.html
@@ -9,6 +9,7 @@
         <th>Id</th>
         <th>Name</th>
         <th>Quantity</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -17,6 +18,7 @@
         <td>{{licence.applicationName}}</td>
         <td>{{licence.quantity}}</td>
         <td>
+            <button class="btn btn-primary m-2 btn-sm" (click)="showLicenceDetails(licence.id)">Users</button>
             <button class="btn btn-primary m-2 btn-sm"(click)="editLicence(licence.id)">Edit</button>
             <button class="btn btn-danger btn-sm" (click)="decreaseQuantity(licence)" [disabled]="licence.quantity === 0">Delete</button>
 

--- a/PA_FE/src/app/licence-table/licence-table.component.ts
+++ b/PA_FE/src/app/licence-table/licence-table.component.ts
@@ -35,6 +35,10 @@ export class LicenceTableComponent {
     this.router.navigate(['editLicence/', id]);
   }
 
+  showLicenceDetails(id: number): void {
+    this.router.navigate(['licenceDetails/', id]);
+  }
+
     decreaseQuantity(licence: Licence): void {
     if (licence.quantity > 0) {
       const updatedLicence = { ...licence, quantity: licence.quantity - 1 };


### PR DESCRIPTION
## Summary
- add API to get licence assignments by licence ID
- expose function in LicenceService
- create LicenceDetails component and route
- show 'Users' action in licence table

## Testing
- `dotnet --version` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a21c0e2c832db2fa7b595a0f3429