### PR TITLE
Fix unrealistic date defaults

### DIFF
--- a/PA_BE/Data/Migrations/20250624223000_FixDateDefaults.cs
+++ b/PA_BE/Data/Migrations/20250624223000_FixDateDefaults.cs
@@ -1,0 +1,102 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PermAdminAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixDateDefaults : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Normalize unrealistic existing values
+            migrationBuilder.Sql(@"
+                UPDATE EmployeeLicences
+                SET AssignedOn = CURRENT_TIMESTAMP
+                WHERE AssignedOn IN ('1970-01-01 00:00:00', '0001-01-01 00:00:00');
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE Licences
+                SET ValidTo = datetime('now','+1 year')
+                WHERE ValidTo IN ('0001-01-01 00:00:00');
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE LicenceInstances
+                SET ValidTo = datetime('now','+1 year')
+                WHERE ValidTo IN ('0001-01-01 00:00:00');
+            ");
+
+            // Recreate Licences table with dynamic default
+            migrationBuilder.Sql(@"
+                CREATE TABLE Licences_temp (
+                    id INTEGER NOT NULL CONSTRAINT PK_Licences PRIMARY KEY AUTOINCREMENT,
+                    ApplicationName TEXT NOT NULL,
+                    Quantity INTEGER NOT NULL,
+                    ValidTo TEXT NOT NULL DEFAULT (datetime('now','+1 year'))
+                );
+                INSERT INTO Licences_temp (id, ApplicationName, Quantity, ValidTo)
+                SELECT id, ApplicationName, Quantity, ValidTo FROM Licences;
+                DROP TABLE Licences;
+                ALTER TABLE Licences_temp RENAME TO Licences;
+            ");
+
+            // Recreate LicenceInstances table with dynamic default
+            migrationBuilder.Sql(@"
+                CREATE TABLE LicenceInstances_temp (
+                    Id INTEGER NOT NULL CONSTRAINT PK_LicenceInstances PRIMARY KEY AUTOINCREMENT,
+                    LicenceId INTEGER NOT NULL,
+                    ValidTo TEXT NOT NULL DEFAULT (datetime('now','+1 year')),
+                    FOREIGN KEY (LicenceId) REFERENCES Licences(id) ON DELETE CASCADE
+                );
+                INSERT INTO LicenceInstances_temp (Id, LicenceId, ValidTo)
+                SELECT Id, LicenceId, ValidTo FROM LicenceInstances;
+                DROP TABLE LicenceInstances;
+                ALTER TABLE LicenceInstances_temp RENAME TO LicenceInstances;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LicenceInstances_LicenceId",
+                table: "LicenceInstances",
+                column: "LicenceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                CREATE TABLE Licences_temp (
+                    id INTEGER NOT NULL CONSTRAINT PK_Licences PRIMARY KEY AUTOINCREMENT,
+                    ApplicationName TEXT NOT NULL,
+                    Quantity INTEGER NOT NULL,
+                    ValidTo TEXT NOT NULL DEFAULT '2025-12-31 00:00:00'
+                );
+                INSERT INTO Licences_temp (id, ApplicationName, Quantity, ValidTo)
+                SELECT id, ApplicationName, Quantity, ValidTo FROM Licences;
+                DROP TABLE Licences;
+                ALTER TABLE Licences_temp RENAME TO Licences;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE TABLE LicenceInstances_temp (
+                    Id INTEGER NOT NULL CONSTRAINT PK_LicenceInstances PRIMARY KEY AUTOINCREMENT,
+                    LicenceId INTEGER NOT NULL,
+                    ValidTo TEXT NOT NULL,
+                    FOREIGN KEY (LicenceId) REFERENCES Licences(id) ON DELETE CASCADE
+                );
+                INSERT INTO LicenceInstances_temp (Id, LicenceId, ValidTo)
+                SELECT Id, LicenceId, ValidTo FROM LicenceInstances;
+                DROP TABLE LicenceInstances;
+                ALTER TABLE LicenceInstances_temp RENAME TO LicenceInstances;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LicenceInstances_LicenceId",
+                table: "LicenceInstances",
+                column: "LicenceId");
+        }
+    }
+}

--- a/PA_FE/src/app/licence-form/licence-form.component.html
+++ b/PA_FE/src/app/licence-form/licence-form.component.html
@@ -29,6 +29,17 @@
         </div>
     </div>
 
+    <div class="mb-3">
+        <label class="form-label">Expiration Date*</label>
+        <input required #validTo="ngModel" class="form-control"
+               type="date" name="validTo" [(ngModel)]="licence.validTo"/>
+        <div *ngIf="validTo.invalid && (validTo.touched || validTo.dirty)">
+            <div class="text-danger" *ngIf="validTo.errors?.['required']">
+                Expiration date is required
+            </div>
+        </div>
+    </div>
+
     <button class="btn btn-primary btn-lg" type="submit" [disabled]="licenceForm.invalid">
         {{isEditing? 'Update' : 'Create'}}
     </button>

--- a/PA_FE/src/app/licence-form/licence-form.component.ts
+++ b/PA_FE/src/app/licence-form/licence-form.component.ts
@@ -17,7 +17,9 @@ export class LicenceFormComponent implements OnInit {
     id: 0,
     applicationName: '',
     quantity: 0,
-    validTo: ''
+    validTo: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .substring(0, 10)
   };
 
   isEditing: boolean = false;
@@ -36,7 +38,10 @@ export class LicenceFormComponent implements OnInit {
         this.isEditing = true;
         this.licenceService.getLicenceById(parseInt(id)).subscribe({
           next: (result) => {
-            this.licence = result;
+            this.licence = {
+              ...result,
+              validTo: result.validTo.substring(0, 10),
+            };
           },
           error: (err) => {
             console.error('Error loading licence', err);


### PR DESCRIPTION
## Summary
- add EF migration to normalize past records and set dynamic defaults
- require valid expiry date on licence form
- revert accidental database change

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b215bdae4832d8d65e23c736c9bc7