### PR TITLE
Add ability to append licence quantity

### DIFF
--- a/PA_FE/src/app/licence-form/licence-form.component.html
+++ b/PA_FE/src/app/licence-form/licence-form.component.html
@@ -7,7 +7,12 @@
     <div class="mb-3">
         <label class="form-label">Application Name*</label>
         <input required #applicationName="ngModel" class="form-control"
-               type="text" name="applicationName" [(ngModel)]="licence.applicationName"/>
+               type="text" name="applicationName" list="licenceNames" (change)="onNameChange(applicationName.value)"
+               [(ngModel)]="licence.applicationName"/>
+        <datalist id="licenceNames">
+          <option value="New license name"></option>
+          <option *ngFor="let name of existingNames" [value]="name"></option>
+        </datalist>
         <div *ngIf="applicationName.invalid && (applicationName.touched || applicationName.dirty)">
             <div class="text-danger" *ngIf="applicationName.errors?.['required']">
                 Application name is required

--- a/PA_FE/src/app/licence-form/licence-form.component.ts
+++ b/PA_FE/src/app/licence-form/licence-form.component.ts
@@ -25,6 +25,8 @@ export class LicenceFormComponent implements OnInit {
   isEditing: boolean = false;
   errorMessage = '';
 
+  existingNames: string[] = [];
+
   constructor(
     private licenceService: LicenceService,
     private router: Router,
@@ -32,6 +34,9 @@ export class LicenceFormComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.licenceService.getLicences().subscribe(ls => {
+      this.existingNames = ls.map(l => l.applicationName);
+    });
     this.route.paramMap.subscribe((params) => {
       const id = params.get('id');
       if (id) {
@@ -49,6 +54,14 @@ export class LicenceFormComponent implements OnInit {
         });
       }
     });
+  }
+
+  onNameChange(value: string): void {
+    if (value === 'New license name') {
+      this.licence.applicationName = '';
+    } else if (this.existingNames.includes(value)) {
+      this.licence.applicationName = value;
+    }
   }
 
   onSubmit(): void {


### PR DESCRIPTION
## Summary
- enable choosing from existing licences when creating a new one
- add datalist for licence names and logic to reset when "new" is picked

## Testing
- `npm test --silent` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3505e288832db928efc2fdcbcf84