### PR TITLE
Add expiry alerts to assigned licenses

### DIFF
--- a/PA_FE/src/app/employee-details/employee-details.component.html
+++ b/PA_FE/src/app/employee-details/employee-details.component.html
@@ -66,14 +66,16 @@
           <th>License Name</th>
           <th>Assigned On</th>
           <th>Expires</th>
+          <th>Alert</th>
           <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let licence of assignedLicences">
+        <tr *ngFor="let licence of assignedLicences" [ngClass]="{ 'table-danger': isExpiringSoon(licence.validTo) }">
           <td>{{ licence.licenceName }}</td>
           <td>{{ licence.assignedOn | date }}</td>
           <td>{{ licence.validTo | date }}</td>
+          <td>{{ isExpiringSoon(licence.validTo) ? 'expires within two weeks' : '' }}</td>
           <td>
             <button
               class="btn btn-danger btn-sm"

--- a/PA_FE/src/app/employee-details/employee-details.component.ts
+++ b/PA_FE/src/app/employee-details/employee-details.component.ts
@@ -74,4 +74,15 @@ export class EmployeeDetailsComponent implements OnInit {
       });
     }
   }
+
+  isExpiringSoon(validTo?: string): boolean {
+    if (!validTo) {
+      return false;
+    }
+    const expiry = new Date(validTo);
+    const now = new Date();
+    const twoWeeksAhead = new Date();
+    twoWeeksAhead.setDate(now.getDate() + 14);
+    return expiry <= twoWeeksAhead;
+  }
 }


### PR DESCRIPTION
## Summary
- highlight soon-to-expire license assignments
- show alert message for licenses expiring in two weeks

## Testing
- `npm test` *(fails: ng not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b45b92c10832db2932e0801336fad