### PR TITLE
Allow deleting individual licence instances

### DIFF
--- a/PA_BE/Controllers/LicenceController.cs
+++ b/PA_BE/Controllers/LicenceController.cs
@@ -155,6 +155,26 @@ public async Task<ActionResult<Licence>> CreateLicence(Licence licence)
             return NoContent();
         }
 
+        [HttpDelete("instance/{instanceId}")]
+        public async Task<IActionResult> DeleteLicenceInstanceById(int instanceId)
+        {
+            var instance = await context.LicenceInstances.FindAsync(instanceId);
+            if (instance == null) return NotFound();
+
+            var licence = await context.Licences.FindAsync(instance.LicenceId);
+
+            context.LicenceInstances.Remove(instance);
+
+            if (licence != null && licence.AvailableLicences > 0)
+            {
+                licence.AvailableLicences--;
+            }
+
+            await context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
         [HttpGet("assigned-licences")]
         public async Task<ActionResult<IEnumerable<AssignLicenceDTO>>> GetAssignedLicences()
         {

--- a/PA_FE/src/_services/licence.service.ts
+++ b/PA_FE/src/_services/licence.service.ts
@@ -29,6 +29,10 @@ export class LicenceService {
     return this.http.delete<void>(`${this.apiUrl}/${id}/instance`);
   }
 
+  deleteLicenceInstanceById(instanceId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/instance/${instanceId}`);
+  }
+
   getLicenceById(id: number): Observable<Licence> {
     return this.http.get<Licence>(`${this.apiUrl}/${id}`);
   }

--- a/PA_FE/src/app/licence-details/licence-details.component.html
+++ b/PA_FE/src/app/licence-details/licence-details.component.html
@@ -29,6 +29,7 @@
             <th>Assigned</th>
             <th>Employee</th>
             <th>Expires</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -36,6 +37,15 @@
             <td>{{ seat.assigned ? 'Yes' : 'No' }}</td>
             <td>{{ seat.employeeName || '-' }}</td>
             <td>{{ seat.validTo | date }}</td>
+            <td>
+              <button
+                class="btn btn-danger btn-sm"
+                (click)="deleteInstance(seat.instanceId)"
+                [disabled]="seat.assigned || seat.instanceId === undefined"
+              >
+                Delete
+              </button>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/PA_FE/src/app/licence-details/licence-details.component.ts
+++ b/PA_FE/src/app/licence-details/licence-details.component.ts
@@ -16,7 +16,7 @@ export class LicenceDetailsComponent implements OnInit {
   licence: Licence | null = null;
   assignedUsers: AssignLicenceDTO[] = [];
   instances: LicenceInstance[] = [];
-  assignments: { validTo: string; assigned: boolean; employeeName?: string }[] = [];
+  assignments: { instanceId?: number; validTo: string; assigned: boolean; employeeName?: string }[] = [];
   errorMessage = '';
 
   constructor(
@@ -80,10 +80,24 @@ export class LicenceDetailsComponent implements OnInit {
       const inst = this.instances[idx];
       const user = this.assignedUsers[idx];
       return {
+        instanceId: inst ? inst.id : undefined,
         validTo: inst ? inst.validTo : this.licence!.validTo,
         assigned: !!user,
         employeeName: user ? user.employeeName : undefined,
       };
+    });
+  }
+
+  deleteInstance(instanceId: number | undefined): void {
+    if (!instanceId || !this.licence) return;
+    this.licenceService.deleteLicenceInstanceById(instanceId).subscribe({
+      next: () => {
+        this.instances = this.instances.filter(i => i.id !== instanceId);
+        this.licence!.availableLicences--;
+        this.licence!.quantity--;
+        this.mergeAssignments();
+      },
+      error: err => console.error('Error deleting instance', err)
     });
   }
 }


### PR DESCRIPTION
## Summary
- add backend endpoint to remove a single licence instance by id
- expose new API method in Angular service
- display a delete button in licence details for each unassigned seat
- handle deletion logic in licence details component

## Testing
- `dotnet test PA_BE/PermAdminAPI.sln` *(fails: command not found)*
- `npm test --prefix PA_FE --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4c4d77a8832da787b01184ac7d86