### PR TITLE
Update licence table alert logic

### DIFF
--- a/PA_FE/src/app/licence-table/licence-table.component.html
+++ b/PA_FE/src/app/licence-table/licence-table.component.html
@@ -10,19 +10,17 @@
         <th>Name</th>
         <th>Available Licences</th>
         <th>Quantity</th>
-        <th>Expires</th>
         <th>Alert</th>
         <th>Actions</th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor = "let licence of licences" [ngClass]="{ 'table-danger': isExpiringSoon(licence.validTo) }">
+      <tr *ngFor = "let licence of licences" [ngClass]="{ 'table-danger': isExpiringSoon(licence.id) }">
         <td>{{licence.id}}</td>
         <td>{{licence.applicationName}}</td>
         <td>{{licence.availableLicences}}</td>
         <td>{{licence.quantity}}</td>
-        <td>{{ licence.validTo | date }}</td>
-        <td>{{ isExpiringSoon(licence.validTo) ? 'expires within two weeks' : '' }}</td>
+        <td>{{ isExpiringSoon(licence.id) ? 'expires within two weeks' : '' }}</td>
         <td>
             <button class="btn btn-primary m-2 btn-sm" (click)="showLicenceDetails(licence.id)">Users</button>
             <button class="btn btn-primary m-2 btn-sm"(click)="editLicence(licence.id)">Edit</button>


### PR DESCRIPTION
## Summary
- remove the *Expires* column from the licence table
- keep alert highlighting when any licence instance expires within two weeks

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bee96e0a8832dab34ae3a79b160e9